### PR TITLE
Update GKE README Instructions on Terraform Destroy

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -56,9 +56,7 @@ gcloud container clusters get-credentials <CLUSTER_NAME> --region=<REGION>
 ```
 
 #### Cleaning up / Deleting resources
-1. Run `terraform destroy` to delete all remaining GCP resources created by this module. You should see `Destroy complete!` message after a few minutes.
-
-** If gpu-operator namespace deletion takes too long run `terraform state rm kubernetes_namespace_v1.gpu-operator`, then rerun `terraform destroy`** 
+1. Run `terraform state rm kubernetes_namespace_v1.gpu-operator` and then run `terraform destroy` to delete all remaining GCP resources created by this module. You should see `Destroy complete!` message after a few minutes.
 
 
 # Terraform Module Information

--- a/gke/examples/cnpack/README.md
+++ b/gke/examples/cnpack/README.md
@@ -24,13 +24,13 @@ This module will add additional GKE specific configuration for use with the [Clo
 
 4. If everything looks correct, run `terraform apply tfplan`
 
-4. To delete the cluster, run `module.holoscan-ready-gke.kubernetes_resource_quota_v1.gpu-operator-quota` then run `terraform destroy`
+5. To delete the cluster, run `terraform state rm module.holoscan-ready-gke.kubernetes_namespace_v1.gpu-operator`, then run `terraform destroy`
 
 
 ### Running CNPack with the CNPack Holoscan Cluster
 1. Once the cluster is created update your kubeconfig:
 ```bash
-gcloud beta container clusters get-credentials <cluster-name> --region <region> --project <project-id>
+gcloud container clusters get-credentials <cluster-name> --region <region> --project <project-id>
 ```
 2. Run `terraform output` to get the needed values to populate the CNPack config file
 


### PR DESCRIPTION
This PR modified two README files:

1. The readme in `GKE/examples/cnpack` :  had the incorrect tf destroy instructions and "beta" in the gcloud fetch cluster credentials command.
2. The readme in main GKE had the rm gpu-operator namespace as a footnote, which many users failed to notice. I edited this section to reduce confusion.
