### PR TITLE
[Chore] Bump AKS and EKS versions explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each CSP has its own end of life date for the versions of Kubernetes they suppor
 
 | Version | Release Date  | Kubernetes Versions                            | NVIDIA GPU Operator    | NVIDIA Data Center Driver* | End of Life |
 | :---    |    :---       | :---                                           | :---                   | :---                      | :--- |
-| 0.3.0     | September 2023 | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.6.1 (Default); 23.3.2 (NV AI E)                 | 535.54.03  (EKS & GKE Default); 525.125.06 (NV AI E version for GKE & EKS)    | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
+| 0.3.0     | September 2023 | EKS -  1.27 <br> GKE - 1.27 <br> AKS - 1.27 | 23.6.1 (Default); 23.3.2 (NV AI E)                 | 535.54.03  (EKS & GKE Default); 525.125.06 (NV AI E version for GKE & EKS)    | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
 | 0.2.0     | August 2023    | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.3.2 | 535.54.03  (EKS & GKE) | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
 | 0.1.0     | June 2023      | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.3.2 | 525.105.17             | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
 

--- a/aks/README.md
+++ b/aks/README.md
@@ -128,7 +128,7 @@ No modules.
 | <a name="input_gpu_node_pool_min_count"></a> [gpu\_node\_pool\_min\_count](#input\_gpu\_node\_pool\_min\_count) | Min count of number of nodes in Default GPU pool | `number` | `2` | no |
 | <a name="input_gpu_operator_version"></a> [gpu\_operator\_version](#input\_gpu\_operator\_version) | Version of the GPU operator to be installed | `string` | `"v23.6.1"` | no |
 | <a name="input_gpu_os_sku"></a> [gpu\_os\_sku](#input\_gpu\_os\_sku) | Specifies the OS SKU used by the agent pool. Possible values include: Ubuntu, CBLMariner, Mariner, Windows2019, Windows2022 | `string` | `"Ubuntu"` | no |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions | `string` | `"1.26.3"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions | `string` | `"1.27.3"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The region to create resources in | `any` | n/a | yes |
 | <a name="input_nvaie"></a> [nvaie](#input\_nvaie) | To use the versions of GPU operator and drivers specified as part of NVIDIA AI Enterprise, set this to true. More information at https://www.nvidia.com/en-us/data-center/products/ai-enterprise | `bool` | `false` | no |
 | <a name="input_nvaie_gpu_operator_version"></a> [nvaie\_gpu\_operator\_version](#input\_nvaie\_gpu\_operator\_version) | The NVIDIA Driver version of GPU Operator. Overrides `gpu_operator_version` when `nvaie` is set to `true` | `string` | `"v23.3.2"` | no |

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -25,7 +25,7 @@ variable "cluster_name" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.26.3"
+  default     = "1.27.3"
   description = "Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions "
 }
 

--- a/eks/README.md
+++ b/eks/README.md
@@ -118,7 +118,7 @@ To create a cluster with everything needed to run the Cloud Native Service Add-o
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | n/a | `string` | `"development"` | no |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | CIDR for VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Version of EKS to install on the control plane (Major and Minor version only, do not include the patch) | `string` | `"1.26"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Version of EKS to install on the control plane (Major and Minor version only, do not include the patch) | `string` | `"1.27"` | no |
 | <a name="input_cpu_instance_type"></a> [cpu\_instance\_type](#input\_cpu\_instance\_type) | CPU EC2 worker node instance type | `string` | `"t2.xlarge"` | no |
 | <a name="input_cpu_node_pool_additional_user_data"></a> [cpu\_node\_pool\_additional\_user\_data](#input\_cpu\_node\_pool\_additional\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script on EKS-managed GPU node pool. | `string` | `""` | no |
 | <a name="input_cpu_node_pool_delete_on_termination"></a> [cpu\_node\_pool\_delete\_on\_termination](#input\_cpu\_node\_pool\_delete\_on\_termination) | Delete the VM nodes root filesystem on each node of the instance type. This is set to true by default, but can be changed when desired when using the 'local-storage provisioner' and are keeping important application data on the nodes | `bool` | `true` | no |

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  default     = "1.26"
+  default     = "1.27"
   description = "Version of EKS to install on the control plane (Major and Minor version only, do not include the patch)"
 }
 /************************


### PR DESCRIPTION
This MR does the following:

Explicitly upgrades K8s versions for EKS and AKS

AKS as of today is at 1.27.3 (validate by running az aks get-versions --location westus --output table ). Note AKS needs the patch version i.e X.Y.Z version set

EKS as of today is at 1.27 see [here](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

GKE is on a "release channel", our default is "regular" which as of today gives 1.27. See [here](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

We will move to 1.28 next month when its available on AKS since the other 2 CSPs have it.


What to test to validate.

1. Provision a new cluster 
2. Run `kubectl version`. The version reported for `server` is what was provisioned.
- AKS will be at 1.27.3. GKE and AKS must be at 1.27.X (where X does not matter)