### PR TITLE
Added a variable for adding GPU Operator Namespace Labels

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -130,6 +130,7 @@ No modules.
 | <a name="input_gpu_min_node_count"></a> [gpu\_min\_node\_count](#input\_gpu\_min\_node\_count) | Min number of GPU nodes in GPU nodepool | `string` | `"2"` | no |
 | <a name="input_gpu_operator_driver_version"></a> [gpu\_operator\_driver\_version](#input\_gpu\_operator\_driver\_version) | The NVIDIA Driver version deployed with GPU Operator. Defaults to latest available. Not set when `nvaie` is set to true | `string` | `"535.104.05"` | no |
 | <a name="input_gpu_operator_namespace"></a> [gpu\_operator\_namespace](#input\_gpu\_operator\_namespace) | The namespace to deploy the NVIDIA GPU operator intov | `string` | `"gpu-operator"` | no |
+| <a name="input_gpu_operator_namespace_labels"></a> [gpu\_operator\_namespace\_labels](#input\_gpu\_operator\_namespace\_labels) | Additional labels to be added to the GPU Operator namespace | `map(string)` | `{}` | no |
 | <a name="input_gpu_operator_version"></a> [gpu\_operator\_version](#input\_gpu\_operator\_version) | Version of the GPU Operator to deploy. Defaults to latest available. Not set when `nvaie` is set to `true` | `string` | `"v23.6.1"` | no |
 | <a name="input_gpu_type"></a> [gpu\_type](#input\_gpu\_type) | GPU SKU To attach to Holoscan GPU Node (eg. nvidia-tesla-k80) | `string` | `"nvidia-tesla-v100"` | no |
 | <a name="input_network"></a> [network](#input\_network) | Network CIDR for VPC | `string` | `""` | no |

--- a/gke/examples/cnpack/main.tf
+++ b/gke/examples/cnpack/main.tf
@@ -7,8 +7,11 @@ CNPack Configuration
 module "holoscan-ready-gke" {
   source       = "../../" # Can also be the git URL+tag when running remotely
   cluster_name = var.cluster_name
-  project_id   = var.project_id 
+  project_id   = var.project_id
   region       = var.region     # Can be any region
   node_zones   = var.node_zones # Can be any region but ensure your desired machine types/gpus exist
+  gpu_operator_namespace_labels = {
+    "platform.nvidia.com/monitoring" = "enabled"
+  }
 }
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -159,10 +159,12 @@ resource "kubernetes_namespace_v1" "gpu-operator" {
       name = "gpu-operator"
     }
 
-    labels = {
+    labels = merge({
       cluster    = var.cluster_name
       managed_by = "Terraform"
-    }
+      },
+      var.gpu_operator_namespace_labels
+    )
 
     name = var.gpu_operator_namespace
   }

--- a/gke/terraform.tfvars
+++ b/gke/terraform.tfvars
@@ -16,6 +16,7 @@
 # gpu_min_node_count                = "2"
 # gpu_operator_driver_version       = "535.104.05"
 # gpu_operator_namespace            = "gpu-operator"
+# gpu_operator_namespace_labels     = {}
 # gpu_operator_version              = "v23.6.1"
 # gpu_type                          = "nvidia-tesla-v100"
 # network                           = ""

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -144,6 +144,13 @@ variable "gpu_operator_namespace" {
   description = "The namespace to deploy the NVIDIA GPU operator intov"
 }
 
+
+variable "gpu_operator_namespace_labels" {
+  description = "Additional labels to be added to the GPU Operator namespace"
+  type        = map(string)
+  default     = {}
+}
+
 variable "nvaie" {
   type        = bool
   default     = false


### PR DESCRIPTION
This MR creates a new variable called `gpu_operator_namespace_labels` which allows user to add any additional labels they want to add on the GPU operator namespace. 

Without this, any changes to the GPU operator namespace labels can easily be overwritten by Terraform commands.