### PR TITLE
Elacey/23.10 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each CSP has its own end of life date for the versions of Kubernetes they suppor
 
 | Version | Release Date  | Kubernetes Versions                            | NVIDIA GPU Operator    | NVIDIA Data Center Driver* | End of Life |
 | :---    |    :---       | :---                                           | :---                   | :---                      | :--- |
+| 0.4.0     | October 2023 | EKS -  1.27 <br> GKE - 1.27 <br> AKS - 1.27 | 23.6.1 (Default); 23.3.2 (NV AI E)                 | 535.104.05  (EKS & GKE Default); 525.125.06 (NV AI E version for GKE & EKS)    | EKS - July 2024 <br> GKE - August 2024  <br> AKS - July 2024 |
 | 0.3.0     | September 2023 | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.6.1 (Default); 23.3.2 (NV AI E)                 | 535.54.03  (EKS & GKE Default); 525.125.06 (NV AI E version for GKE & EKS)    | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
 | 0.2.0     | August 2023    | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.3.2 | 535.54.03  (EKS & GKE) | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |
 | 0.1.0     | June 2023      | EKS -  1.26 <br> GKE - 1.26 <br> AKS - 1.26 | 23.3.2 | 525.105.17             | EKS - June 2024 <br> GKE - June 2024  <br> AKS - March 2024 |

--- a/aks/README.md
+++ b/aks/README.md
@@ -128,7 +128,7 @@ No modules.
 | <a name="input_gpu_node_pool_min_count"></a> [gpu\_node\_pool\_min\_count](#input\_gpu\_node\_pool\_min\_count) | Min count of number of nodes in Default GPU pool | `number` | `2` | no |
 | <a name="input_gpu_operator_version"></a> [gpu\_operator\_version](#input\_gpu\_operator\_version) | Version of the GPU operator to be installed | `string` | `"v23.6.1"` | no |
 | <a name="input_gpu_os_sku"></a> [gpu\_os\_sku](#input\_gpu\_os\_sku) | Specifies the OS SKU used by the agent pool. Possible values include: Ubuntu, CBLMariner, Mariner, Windows2019, Windows2022 | `string` | `"Ubuntu"` | no |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions | `string` | `"1.27.3"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions | `string` | `"1.27"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The region to create resources in | `any` | n/a | yes |
 | <a name="input_nvaie"></a> [nvaie](#input\_nvaie) | To use the versions of GPU operator and drivers specified as part of NVIDIA AI Enterprise, set this to true. More information at https://www.nvidia.com/en-us/data-center/products/ai-enterprise | `bool` | `false` | no |
 | <a name="input_nvaie_gpu_operator_version"></a> [nvaie\_gpu\_operator\_version](#input\_nvaie\_gpu\_operator\_version) | The NVIDIA Driver version of GPU Operator. Overrides `gpu_operator_version` when `nvaie` is set to `true` | `string` | `"v23.3.2"` | no |

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -25,7 +25,7 @@ variable "cluster_name" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.26.3"
+  default     = "1.27"
   description = "Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions "
 }
 

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_name" {
 
 variable "cluster_version" {
   type        = string
-  default     = "1.26"
+  default     = "1.27"
   description = "Version of EKS to install on the control plane (Major and Minor version only, do not include the patch)"
 }
 /************************


### PR DESCRIPTION
Upgrade K8s versions to 1.27 in AKS (GKE auto upgrades, current release channel is 1.27)