### PR TITLE
Updated private and public subnet ranges for VPC in EKS

### DIFF
--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -210,13 +210,13 @@ variable "additional_user_data" {
 variable "private_subnets" {
   type        = list(any)
   description = "List of subnet ranges for the Holoscan VPC"
-  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  default     = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
 }
 
 variable "public_subnets" {
   type        = list(any)
   description = "List of subnet ranges for the Holoscan VPC"
-  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  default     = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
 }
 
 variable "ssh_key" {


### PR DESCRIPTION
This change increases the default HCN VPC Subnet for all users. This is to avoid running our of IP addresses when deploying a large cluster (>100 nodes).

All pods and nodes created using the TF module share the same subnet. There are 6 - 3 public subnets and 3 private subnets each in a zone. We need to split the /16 (cidr_block) into 6. With /24 subnet mask we were under-utilizing the IP address space.

Number of IP Addresses available under /19 subnet mask is 8,192.
With /24, we had 256*3=768 ip addresses available each for private and public subnet.
If we consider 100 node cluster = 100 ip addresses (1 for each node).
Each node can have at max 44 pods so about 44 * 100 = 4400 ip addresses. So total we need about 4500 ip addresses.
This is default value that should be able to support atleast 180 node cluster with 8192 IP addresses without running out of ip addresses. If someone wants to create a cluster bigger than this then they can update this value. 