### PR TITLE
Standardize the gpu-operator namespace/helm installation in AKS module

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -57,7 +57,7 @@ We strongly encourage you [configure remote state](https://developer.hashicorp.c
 
 
 5. Cleanup/uninstall
-    - Run `terraform destroy` to delete all resources created by this module. 
+   - Run `terraform state rm kubernetes_namespace_v1.gpu-operator` and then run `terraform destroy` to delete all resources created by this module.
 
 ### CNPack
 
@@ -93,6 +93,8 @@ To create a cluster with everything needed to run the Cloud Native Service Add-o
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.48.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.19.0 |
 
 ## Modules
 
@@ -105,6 +107,8 @@ No modules.
 | [azurerm_kubernetes_cluster.holoscan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.holoscan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_resource_group.holoscan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [helm_release.gpu-operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_namespace_v1.gpu-operator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [azurerm_kubernetes_cluster.holoscancluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_resource_group.existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
@@ -126,6 +130,7 @@ No modules.
 | <a name="input_gpu_node_pool_disk_size"></a> [gpu\_node\_pool\_disk\_size](#input\_gpu\_node\_pool\_disk\_size) | Disk size in GB of nodes in the Default GPU pool | `number` | `100` | no |
 | <a name="input_gpu_node_pool_max_count"></a> [gpu\_node\_pool\_max\_count](#input\_gpu\_node\_pool\_max\_count) | Max count of nodes in Default GPU pool | `number` | `5` | no |
 | <a name="input_gpu_node_pool_min_count"></a> [gpu\_node\_pool\_min\_count](#input\_gpu\_node\_pool\_min\_count) | Min count of number of nodes in Default GPU pool | `number` | `2` | no |
+| <a name="input_gpu_operator_namespace"></a> [gpu\_operator\_namespace](#input\_gpu\_operator\_namespace) | The namespace to deploy the NVIDIA GPU operator into | `string` | `"gpu-operator"` | no |
 | <a name="input_gpu_operator_version"></a> [gpu\_operator\_version](#input\_gpu\_operator\_version) | Version of the GPU operator to be installed | `string` | `"v23.6.1"` | no |
 | <a name="input_gpu_os_sku"></a> [gpu\_os\_sku](#input\_gpu\_os\_sku) | Specifies the OS SKU used by the agent pool. Possible values include: Ubuntu, CBLMariner, Mariner, Windows2019, Windows2022 | `string` | `"Ubuntu"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of Kubernetes to turn on. Run 'az aks get-versions --location <location> --output table' to view all available versions | `string` | `"1.27"` | no |

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -80,7 +80,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "holoscan" {
   }
 }
 
-
 /***************************
 Create GPU Operator Namespace
 ***************************/

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -126,7 +126,7 @@ resource "helm_release" "gpu-operator" {
 
   set {
     name  = "driver.enabled"
-    value = "true"
+    value = "false"
   }
 
 }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -78,15 +78,46 @@ resource "azurerm_kubernetes_cluster_node_pool" "holoscan" {
     group      = "Holoscan"
     managed_by = "Terraform"
   }
-  // Add NVIDIA NGC Helm Repo to local helm repo via local-exec command
-  provisioner "local-exec" {
-    command = "helm repo add nvidia https://helm.ngc.nvidia.com/nvidia"
+}
+
+
+/***************************
+Create GPU Operator Namespace
+***************************/
+resource "kubernetes_namespace_v1" "gpu-operator" {
+  metadata {
+    annotations = {
+      name = "gpu-operator"
+    }
+
+    labels = {
+      cluster    = var.cluster_name
+      managed_by = "Terraform"
+    }
+
+    name = var.gpu_operator_namespace
   }
-  // install the GPU operator on successful creation of the node pool via local-exec command.
-  // This solves any errors attempting to use the helm provider on a cluster that is not yet created
-  // and allows for configuration of the cluster in a single provisioning step.
-  // Run "helm upgrade --install" for idempotency
-  provisioner "local-exec" {
-    command = "helm upgrade --install  gpu-operator --version ${var.nvaie ? var.nvaie_gpu_operator_version : var.gpu_operator_version} --create-namespace --namespace gpu-operator nvidia/gpu-operator --set toolkit.enabled=true --set operator.cleanupCRD=true --set driver.enabled=false"
+}
+
+/***************************
+GPU Operator Configuration
+***************************/
+resource "helm_release" "gpu-operator" {
+  depends_on       = [azurerm_kubernetes_cluster_node_pool.holoscan, kubernetes_namespace_v1.gpu-operator]
+  name             = "gpu-operator"
+  repository       = "https://helm.ngc.nvidia.com/nvidia"
+  chart            = "gpu-operator"
+  version          = var.nvaie ? var.nvaie_gpu_operator_version : var.gpu_operator_version
+  namespace        = var.gpu_operator_namespace
+  create_namespace = false
+  atomic           = true
+  cleanup_on_fail  = true
+  reset_values     = true
+  replace          = true
+
+  set {
+    name  = "driver.version"
+    value = var.nvaie ? var.nvaie_gpu_operator_driver_version : var.gpu_operator_driver_version
   }
+
 }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -116,8 +116,18 @@ resource "helm_release" "gpu-operator" {
   replace          = true
 
   set {
-    name  = "driver.version"
-    value = var.nvaie ? var.nvaie_gpu_operator_driver_version : var.gpu_operator_driver_version
+    name  = "toolkit.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "operator.cleanupCRD"
+    value = "true"
+  }
+
+  set {
+    name  = "driver.enabled"
+    value = "true"
   }
 
 }

--- a/aks/providers.tf
+++ b/aks/providers.tf
@@ -4,3 +4,19 @@
 provider "azurerm" {
   features {}
 }
+
+provider "kubernetes" {
+  host                   = azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.holoscan.kube_admin_config.0.cluster_ca_certificate)
+  }
+}

--- a/aks/terraform.tfvars
+++ b/aks/terraform.tfvars
@@ -18,6 +18,7 @@
 # gpu_node_pool_disk_size      = 100
 # gpu_node_pool_max_count      = 5
 # gpu_node_pool_min_count      = 2
+# gpu_operator_namespace       = "gpu-operator"
 # gpu_operator_version         = "v23.6.1"
 # gpu_os_sku                   = "Ubuntu"
 # kubernetes_version           = "1.26.3"

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -91,6 +91,12 @@ variable "gpu_operator_version" {
   description = "Version of the GPU operator to be installed"
 }
 
+variable "gpu_operator_namespace" {
+  type        = string
+  default     = "gpu-operator"
+  description = "The namespace to deploy the NVIDIA GPU operator into"
+}
+
 variable "nvaie" {
   type        = bool
   default     = false

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -141,7 +141,7 @@ variable "gpu_operator_driver_version" {
 variable "gpu_operator_namespace" {
   type        = string
   default     = "gpu-operator"
-  description = "The namespace to deploy the NVIDIA GPU operator intov"
+  description = "The namespace to deploy the NVIDIA GPU operator into"
 }
 
 variable "nvaie" {


### PR DESCRIPTION
This PR attempts to standardize the gpu-operator installation in the AKS module (with the EKS/GKE modules).

Instead of leveraging a local-exec provisioner, this change adopts the Terraform-native resources to manage the namespace creation and the helm installation.