### PR TITLE
Set AWS PCA to use short-lived mode

### DIFF
--- a/eks/examples/cnpack/.terraform.lock.hcl
+++ b/eks/examples/cnpack/.terraform.lock.hcl
@@ -46,26 +46,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.3.1"
-  hashes = [
-    "h1:9rJggijNdRdFk//ViQPGZdK0xu9XU/9qBDijNsZJMg0=",
-    "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
-    "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
-    "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
-    "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
-    "zh:472a71c624952cff7aa98a7b967f6c7bb53153dbd2b8f356ceb286e6743bb4e2",
-    "zh:4cff06d31272aac8bc35e9b7faec42cf4554cbcbae1092eaab6ab7f643c215d9",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7ed16ccd2049fa089616b98c0bd57219f407958f318f3c697843e2397ddf70df",
-    "zh:842696362c92bf2645eb85c739410fd51376be6c488733efae44f4ce688da50e",
-    "zh:8985129f2eccfd7f1841ce06f3bf2bbede6352ec9e9f926fbaa6b1a05313b326",
-    "zh:a5f0602d8ec991a5411ef42f872aa90f6347e93886ce67905c53cfea37278e05",
-    "zh:bf4ab82cbe5256dcef16949973bf6aa1a98c2c73a98d6a44ee7bc40809d002b8",
-    "zh:e70770be62aa70198fa899526d671643ff99eecf265bf1a50e798fc3480bd417",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/helm" {
   version = "2.9.0"
   hashes = [

--- a/eks/examples/cnpack/README.md
+++ b/eks/examples/cnpack/README.md
@@ -6,7 +6,7 @@ This module will add additional AWS specific configuration for use with CNPack
 
 - AWS Managed Prometheus and corresponding IAM roles
 
-- AWS Private Certificate Authority and corresponding IAM roles
+- AWS Private Certificate Authority and corresponding IAM roles ([Short-Lived Mode](https://docs.aws.amazon.com/privateca/latest/userguide/short-lived-certificates.html))
 
 - Node Role Policy for FluentBit connection
 
@@ -224,8 +224,9 @@ No requirements.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
 | <a name="input_common_name"></a> [common\_name](#input\_common\_name) | Common Name for PCA Creation | `string` | `"cluster.local"` | no |
 | <a name="input_fluentbit_enabled"></a> [fluentbit\_enabled](#input\_fluentbit\_enabled) | Set to true to enable, false to disable | `bool` | `true` | no |
-| <a name="input_metrics_server_enabled"></a> [metrics\_server\_enabled](#input\_metrics\_server\_enabled) | Set to true to enable the network support for Metrics Server, false to disable | `bool` | `false` | no |
+| <a name="input_metrics_server_enabled"></a> [metrics\_server\_enabled](#input\_metrics\_server\_enabled) | Set to true to enable the network support for Metrics Server, false to disable | `bool` | `true` | no |
 | <a name="input_pca_enabled"></a> [pca\_enabled](#input\_pca\_enabled) | Set to true to enable, false to disable | `bool` | `true` | no |
+| <a name="input_pca_short_lived"></a> [pca\_short\_lived](#input\_pca\_short\_lived) | Set to true to use AWS PCA in the short lived mode, false to use general purpose mode | `bool` | `true` | no |
 | <a name="input_prom_adapter_enabled"></a> [prom\_adapter\_enabled](#input\_prom\_adapter\_enabled) | Set to true to enable the network support for Prometheus Adapter, false to disable | `bool` | `true` | no |
 
 ## Outputs

--- a/eks/examples/cnpack/aws-pca.tf
+++ b/eks/examples/cnpack/aws-pca.tf
@@ -9,6 +9,7 @@ AWS Private Cert Authority Config
 resource "aws_acmpca_certificate_authority" "cnpack-pca" {
   count = var.pca_enabled ? 1 : 0
   type  = "ROOT"
+  usage_mode = var.pca_short_lived ? "SHORT_LIVED_CERTIFICATE" : "GENERAL_PURPOSE"
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"

--- a/eks/examples/cnpack/terraform.tfvars
+++ b/eks/examples/cnpack/terraform.tfvars
@@ -10,4 +10,5 @@
 # fluentbit_enabled      = true
 # metrics_server_enabled = true
 # pca_enabled            = true
+# pca_short_lived        = true
 # prom_adapter_enabled   = true

--- a/eks/examples/cnpack/testcert.yaml
+++ b/eks/examples/cnpack/testcert.yaml
@@ -10,12 +10,12 @@ spec:
   commonName: cluster.local
   dnsNames:
     - test.cluster.local
-  duration: 2160h0m0s
+  duration: 160h0m0s
   issuerRef:
     group: awspca.cert-manager.io
     kind: AWSPCAClusterIssuer
     name: nvidia-platform
-  renewBefore: 360h0m0s
+  renewBefore: 16h0m0s
   secretName: rsa-cert-4096
   usages:
     - server auth

--- a/eks/examples/cnpack/variables.tf
+++ b/eks/examples/cnpack/variables.tf
@@ -27,6 +27,12 @@ variable "pca_enabled" {
   description = "Set to true to enable, false to disable"
 }
 
+variable "pca_short_lived" {
+  type        = bool
+  default     = true
+  description = "Set to true to use AWS PCA in the short lived mode, false to use general purpose mode"
+}
+
 variable "common_name" {
   type        = string
   default     = "cluster.local"


### PR DESCRIPTION
There is a cheaper option $50 vs $400 for enabling certificates in AWS. We should offer and default to the cheaper option.

background: 
* https://aws.amazon.com/private-ca/pricing/
* https://docs.aws.amazon.com/privateca/latest/userguide/short-lived-certificates.html


