### PR TITLE
Bug fix on aws-fluentbit for IAM role for cloudwatch

### DIFF
--- a/eks/examples/cnpack/aws-fluentbit.tf
+++ b/eks/examples/cnpack/aws-fluentbit.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 /*******************************************
@@ -11,7 +11,7 @@ data "aws_iam_policy" "cloudwatch-agent-server-policy" {
   name  = "CloudWatchAgentServerPolicy"
 }
 
-// IAM Policy to attach CPU node pools to Amazon Managed Cloud Watch Policy
+// IAM Policy to attach GPU node pools to Amazon Managed Cloud Watch Policy
 resource "aws_iam_role_policy_attachment" "attach-cloudwatch-to-gpu-ng" {
   count      = var.fluentbit_enabled ? 1 : 0
   role       = module.holoscan-eks-cluster.gpu_node_role_name
@@ -21,6 +21,6 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-to-gpu-ng" {
 // IAM Policy to attach CPU node pools to Amazon Managed Cloud Watch Policy
 resource "aws_iam_role_policy_attachment" "attach-cloudwatch-to-cpu-ng" {
   count      = var.fluentbit_enabled ? 1 : 0
-  role       = module.holoscan-eks-cluster.gpu_node_role_name
+  role       = module.holoscan-eks-cluster.cpu_node_role_name
   policy_arn = data.aws_iam_policy.cloudwatch-agent-server-policy[count.index].arn
 }


### PR DESCRIPTION
The IAM Policy to attach CPU node pools to Amazon Managed Cloud Watch Policy had a typo and was actually attaching to the GPU IAM Role, which caused the bug of `[2024/01/10 09:36:50] [error] [output:cloudwatch_logs:cloudwatch_logs.0] CreateLogStream API responded with error='AccessDeniedException'` on CPU nodes.

This PR fixes this issue.