### PR TITLE
Update copyright header to 2024 for AWS PCA change

### DIFF
--- a/eks/examples/cnpack/aws-pca.tf
+++ b/eks/examples/cnpack/aws-pca.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 /*******************************************

--- a/eks/examples/cnpack/terraform.tfvars
+++ b/eks/examples/cnpack/terraform.tfvars
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Sample tfvars file. Uncomment out values to use

--- a/eks/examples/cnpack/testcert.yaml
+++ b/eks/examples/cnpack/testcert.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 kind: Certificate

--- a/eks/examples/cnpack/variables.tf
+++ b/eks/examples/cnpack/variables.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 /*******************************************


### PR DESCRIPTION
The previous PR https://github.com/NVIDIA/nvidia-terraform-modules/pull/22 did not have update in copyright header. Apologies.