### PR TITLE
pin ebs_csi_irsa_role module version to 5.43.0, ignore tf lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tfstate.*
 crash.log
 tfplan
+.terraform.lock.hcl

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -144,6 +144,7 @@ module "eks" {
 ********************************************/
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version               = "5.43.0"
   role_name             = "${var.cluster_name}-ebs-csi"
   attach_ebs_csi_policy = true
   oidc_providers = {


### PR DESCRIPTION
What this PR introduces:
It pins the `ebs_csi_irsa_role` module version to make the eks nvidia terraform module usable for newcomers

Explanation:
5.43.0 is the latest compatible version of `ebs_csi_irsa_role` that is compatible with the current input.
By default, when running `terraform init` the latest version of the module gets downloaded that is incompatible with the inputs

Ways to reproduce:
1. Delete .terraform folder and run `terraform init` 
2. Or just run `terraform init --upgrade`

Proposal:
1. It's possible to migrate to a newer major version of `ebs_csi_irsa_role`, but it will require changing the input format. might be worth doing it in order to stay up to date with latest aws terraform modules

@francisguillier would appreciate your review
